### PR TITLE
Make rust58 compatible with current master.

### DIFF
--- a/src/base58.rs
+++ b/src/base58.rs
@@ -80,7 +80,9 @@ impl FromBase58 for [u8] {
             r.push(0);
         }
         if x > Zero::zero() {
-            r.push(x.to_bytes_be());
+            for eachbyte in x.to_bytes_be() {
+              r.push(eachbyte);
+            }
         }
         Ok(r)
     }

--- a/src/base58.rs
+++ b/src/base58.rs
@@ -80,7 +80,7 @@ impl FromBase58 for [u8] {
             r.push(0);
         }
         if x > Zero::zero() {
-            r.append(&mut x.to_bytes_be());
+            r.push(x.to_bytes_be());
         }
         Ok(r)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(collections)]
-
 extern crate num;
 #[cfg(test)] extern crate rand;
 


### PR DESCRIPTION
The current code relies on append, which is not yet in stable. I modified to use push instead so it can be used in stable rustc. If there was a reason you weren't doing it this way, feel free to disregard.
