### PR TITLE
add base58 check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ Simple library for converting to and from base-58 strings.
 
 [dependencies]
 num = "*"
+sha2 = "0.7.1"
 
 [dev-dependencies]
 rand = "*"


### PR DESCRIPTION
The checksum is calculated as `data_to_encode||sha256(sha256(data_to_encode))[:4]`
`||` denotes concatenation and `[:4]` denotes taking first 4 bytes. Matches implementation of [python base58 library](https://github.com/keis/base58)

Signed-off-by: Lovesh Harchandani <lovesh.bond@gmail.com>